### PR TITLE
feat: add SinkS3 for uploading JSONL to S3-compatible stores

### DIFF
--- a/shuntly/__init__.py
+++ b/shuntly/__init__.py
@@ -1,6 +1,6 @@
 from shuntly.core import shunt
 from shuntly.record import ShuntlyRecord
-from shuntly.sinks import Sink, SinkFile, SinkMany, SinkPipe, SinkStream
+from shuntly.sinks import Sink, SinkFile, SinkMany, SinkPipe, SinkS3, SinkStream
 
 __all__ = [
     'shunt',
@@ -9,5 +9,6 @@ __all__ = [
     'SinkFile',
     'SinkMany',
     'SinkPipe',
+    'SinkS3',
     'SinkStream',
 ]

--- a/shuntly/sinks.py
+++ b/shuntly/sinks.py
@@ -105,6 +105,106 @@ class SinkPipe(Sink):
             self._fd = None
 
 
+class SinkS3(Sink):
+    """A Sink that buffers JSONL records and uploads them as objects to any
+    S3-compatible store (AWS S3, Cloudflare R2, Backblaze B2, MinIO, etc.).
+
+    Records are buffered in memory and uploaded as a new object when the buffer
+    reaches *max_bytes_file* or when :meth:`close` is called.  Objects are
+    named with ISO-8601 timestamps (e.g.
+    ``prefix/2025-02-15T210530.482371Z.jsonl``).
+
+    Retention / pruning is expected to be handled by the storage provider
+    (e.g. S3 lifecycle rules, R2 object lifecycle).
+
+    Requires the ``boto3`` package (not a hard dependency of shuntly).
+
+    Args:
+        bucket: Bucket name.
+        access_key_id: S3-compatible access key ID.
+        secret_access_key: S3-compatible secret access key.
+        endpoint_url: Custom endpoint URL for S3-compatible providers
+            (e.g. ``https://<account_id>.r2.cloudflarestorage.com`` for
+            Cloudflare R2).  Omit for AWS S3.
+        region: AWS region (optional, defaults to ``us-east-1``).
+        prefix: Key prefix for uploaded objects (e.g. ``"prod/"``).
+            Defaults to ``""``.
+        max_bytes_file: Maximum buffer size in bytes before uploading a new
+            object.  Defaults to 10 MB.
+    """
+
+    __slots__ = (
+        '_bucket',
+        '_prefix',
+        '_max_bytes_file',
+        '_client',
+        '_buffer',
+        '_buffer_size',
+    )
+
+    _DEFAULT_MAX_BYTES_FILE = 10 * 1024 * 1024  # 10 MB
+
+    def __init__(
+        self,
+        bucket: str,
+        *,
+        access_key_id: str,
+        secret_access_key: str,
+        endpoint_url: str | None = None,
+        region: str = 'us-east-1',
+        prefix: str = '',
+        max_bytes_file: int = _DEFAULT_MAX_BYTES_FILE,
+    ):
+        self._bucket = bucket
+        self._prefix = prefix
+        self._max_bytes_file = max_bytes_file
+        self._buffer: list[str] = []
+        self._buffer_size: int = 0
+        try:
+            import boto3 as _boto3  # type: ignore[import-untyped]
+        except ImportError as exc:
+            raise ImportError('SinkS3 requires boto3: pip install boto3') from exc
+
+        self._client = _boto3.client(
+            's3',
+            aws_access_key_id=access_key_id,
+            aws_secret_access_key=secret_access_key,
+            endpoint_url=endpoint_url,
+            region_name=region,
+        )
+
+    @staticmethod
+    def _make_key(prefix: str) -> str:
+        from datetime import datetime, timezone
+
+        ts = datetime.now(timezone.utc).strftime('%Y-%m-%dT%H%M%S.%fZ')
+        return f'{prefix}{ts}.jsonl'
+
+    def _flush(self) -> None:
+        if not self._buffer:
+            return
+        key = self._make_key(self._prefix)
+        body = ''.join(self._buffer)
+        self._client.put_object(
+            Bucket=self._bucket,
+            Key=key,
+            Body=body.encode(),
+            ContentType='application/x-ndjson',
+        )
+        self._buffer.clear()
+        self._buffer_size = 0
+
+    def write(self, record: ShuntlyRecord) -> None:
+        line = record.to_json() + '\n'
+        self._buffer.append(line)
+        self._buffer_size += len(line.encode())
+        if self._buffer_size >= self._max_bytes_file:
+            self._flush()
+
+    def close(self) -> None:
+        self._flush()
+
+
 class SinkMany(Sink):
     def __init__(self, sinks: list[Sink]):
         self._sinks = sinks

--- a/test/unit/test_sinks.py
+++ b/test/unit/test_sinks.py
@@ -3,7 +3,9 @@ import json
 import os
 import tempfile
 
-from shuntly import ShuntlyRecord, SinkFile, SinkMany, SinkStream
+from unittest.mock import MagicMock
+
+from shuntly import ShuntlyRecord, SinkFile, SinkMany, SinkS3, SinkStream
 
 
 def _make_record(**overrides) -> ShuntlyRecord:
@@ -64,6 +66,63 @@ class TestSinkFile:
             sink.close()  # should not raise
         finally:
             os.unlink(path)
+
+
+def _make_s3_sink(**kwargs) -> tuple[SinkS3, MagicMock]:
+    defaults = dict(
+        bucket='test-bucket',
+        access_key_id='AKID',
+        secret_access_key='SECRET',
+    )
+    defaults.update(kwargs)
+    sink = SinkS3(**defaults)
+    mock_client = MagicMock()
+    sink._client = mock_client
+    return sink, mock_client
+
+
+class TestSinkS3:
+    def test_uploads_on_close(self):
+        sink, mock_client = _make_s3_sink()
+        sink.write(_make_record())
+        sink.write(_make_record())
+        mock_client.put_object.assert_not_called()
+
+        sink.close()
+        mock_client.put_object.assert_called_once()
+        call_kwargs = mock_client.put_object.call_args[1]
+        assert call_kwargs['Bucket'] == 'test-bucket'
+        assert call_kwargs['Key'].endswith('.jsonl')
+        assert call_kwargs['ContentType'] == 'application/x-ndjson'
+        body = call_kwargs['Body'].decode()
+        lines = body.strip().split('\n')
+        assert len(lines) == 2
+
+    def test_flushes_on_max_bytes(self):
+        sink, mock_client = _make_s3_sink(max_bytes_file=50)
+        for _ in range(5):
+            sink.write(_make_record())
+        assert mock_client.put_object.call_count >= 1
+        sink.close()
+
+    def test_prefix_in_key(self):
+        sink, mock_client = _make_s3_sink(prefix='prod/logs/')
+        sink.write(_make_record())
+        sink.close()
+        key = mock_client.put_object.call_args[1]['Key']
+        assert key.startswith('prod/logs/')
+
+    def test_no_upload_when_empty(self):
+        sink, mock_client = _make_s3_sink()
+        sink.close()
+        mock_client.put_object.assert_not_called()
+
+    def test_close_is_idempotent(self):
+        sink, mock_client = _make_s3_sink()
+        sink.write(_make_record())
+        sink.close()
+        sink.close()  # should not upload again
+        assert mock_client.put_object.call_count == 1
 
 
 class TestSinkMulti:


### PR DESCRIPTION
## Summary

Adds `SinkS3`, a sink that buffers records in memory and uploads them as timestamped JSONL objects to any S3-compatible store (AWS S3, Cloudflare R2, Backblaze B2, MinIO, etc.).

**Status: Draft / exploratory** — not yet sure this should ship. PR exists to capture the design.

## API

```python
from shuntly import shunt, SinkS3

# Cloudflare R2
client = shunt(Anthropic(), SinkS3(
    bucket="shuntly-logs",
    access_key_id="...",
    secret_access_key="...",
    endpoint_url="https://abc123.r2.cloudflarestorage.com",
))

# AWS S3 (no endpoint_url needed)
client = shunt(Anthropic(), SinkS3(
    bucket="shuntly-logs",
    access_key_id="...",
    secret_access_key="...",
    region="us-east-1",
))
```

## Design Decisions

- **`SinkS3` not `SinkR2`** — S3 is the protocol, providers are just endpoints
- **Explicit credentials** — no env var conventions; users wrap `os.environ` if they want
- **No client-side pruning** — provider lifecycle rules handle retention
- **`max_bytes_file`** — controls when to flush buffer and upload (default 10 MB)
- **Lazy `boto3` import** — not a hard dependency

## Tests

5 unit tests with mocked S3 client. All 24 tests pass. ruff and mypy clean.

Fixes #7