### PR TITLE
feat: add support for Mozilla AI any-llm

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ A lightweight wiretap for LLM SDKs: capture all requests and responses with a si
 
 Shuntly wraps LLM SDKs to record every request and response as JSON. Calling `shunt()` wraps and returns a client with its original interface and types preserved, permitting consistent IDE autocomplete and type checking. Shuntly provides a collection of configurable "sinks" to write records to stderr, files, named pipes, or any combination.
 
-While debugging LLM tooling, maybe you want to see exactly what is being sent and returned. When launching an agent, maybe you want to record every call to the LLM. Shuntly can capture it all without TLS interception, a web-based platform, or complicated logging infrastructure.
+While debugging LLM tooling, maybe you want to see exactly what is being sent and returned. When launching an agent, maybe you want to record every call to the LLM. Shuntly can capture it all without TLS interception, a proxy or web-based platform, or complicated logging infrastructure.
 
 
 ## Install
@@ -145,6 +145,7 @@ Shuntly presently handles these clients:
 | `openai.OpenAI` | [`PyPI`](https://pypi.org/project/openapi) | `chat.completions.create` |
 | `google.genai.Client` | [`PyPI`](https://pypi.org/project/google-genai) | `models.generate_content` |
 | `litellm` | [`PyPI`](https://pypi.org/project/litellm) | `completion` |
+| `any-llm` | [`PyPI`](https://pypi.org/project/any-llm-sdk) | `completion` |
 
 For anything else, method paths can be explicitly provided:
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ dev = [
     "build==1.4.0",
     "litellm==1.81.10",
     "python-dotenv==1.2.1",
+    "any-llm-sdk==1.8.5",
     ]
 
 [tool.setuptools.packages.find]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ dev = [
     "build==1.4.0",
     "litellm==1.81.10",
     "python-dotenv==1.2.1",
-    "any-llm-sdk==1.8.5",
+    "any-llm-sdk[openai]==1.8.5",
     ]
 
 [tool.setuptools.packages.find]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ dev = [
     "build==1.4.0",
     "litellm==1.81.10",
     "python-dotenv==1.2.1",
-    "any-llm-sdk[openai]==1.8.5",
+    "any-llm-sdk[openai]==1.8.5; python_version>='3.11'",
     ]
 
 [tool.setuptools.packages.find]

--- a/shuntly/core.py
+++ b/shuntly/core.py
@@ -26,6 +26,9 @@ _METHOD_REGISTRY: dict[str, list[str]] = {
     'litellm': [
         'completion',
     ],
+    'any_llm': [
+        'completion',
+    ],
 }
 
 

--- a/test/adhoc/test_any_llm.py
+++ b/test/adhoc/test_any_llm.py
@@ -57,6 +57,4 @@ def test_wrap_captures_alternative_syntax():
     assert record['request']['model'] == f'openai:{_MODEL}'
     assert record['error'] is None
     assert record['duration_ms'] > 0
-    assert (
-        record['response']['choices'][0]['message']['content'].lower().strip() == 'red'
-    )
+    assert record['response']['choices'][0]['message']['content'].lower().strip() == 'red'

--- a/test/adhoc/test_any_llm.py
+++ b/test/adhoc/test_any_llm.py
@@ -1,16 +1,24 @@
 import io
 import json
 import os
+import sys
 
-import any_llm
 import pytest
+
+if sys.version_info >= (3, 11):
+    import any_llm
 
 from shuntly import SinkStream, shunt
 
 _OPENAI_API_KEY = os.environ.get('OPENAI_API_KEY')
 _MODEL = 'gpt-4o-mini'
 
-pytestmark = pytest.mark.skipif(not _OPENAI_API_KEY, reason='OPENAI_API_KEY not set')
+pytestmark = [
+    pytest.mark.skipif(
+        sys.version_info < (3, 11), reason='any-llm-sdk requires Python >= 3.11'
+    ),
+    pytest.mark.skipif(not _OPENAI_API_KEY, reason='OPENAI_API_KEY not set'),
+]
 
 
 def test_wrap_captures_record():

--- a/test/adhoc/test_any_llm.py
+++ b/test/adhoc/test_any_llm.py
@@ -2,17 +2,13 @@ import io
 import json
 import os
 
+import any_llm
 import pytest
-
-try:
-    import any_llm
-except ImportError:
-    pytest.skip("any-llm-sdk not available", allow_module_level=True)
 
 from shuntly import SinkStream, shunt
 
 _OPENAI_API_KEY = os.environ.get('OPENAI_API_KEY')
-_MODEL = 'gpt-3.5-turbo'
+_MODEL = 'gpt-4o-mini'
 
 pytestmark = pytest.mark.skipif(not _OPENAI_API_KEY, reason='OPENAI_API_KEY not set')
 
@@ -37,7 +33,9 @@ def test_wrap_captures_record():
     assert record['request']['provider'] == 'openai'
     assert record['error'] is None
     assert record['duration_ms'] > 0
-    assert record['response']['choices'][0]['message']['content'].lower().strip() == 'pong'
+    assert (
+        record['response']['choices'][0]['message']['content'].lower().strip() == 'pong'
+    )
 
 
 def test_wrap_captures_alternative_syntax():
@@ -46,17 +44,19 @@ def test_wrap_captures_alternative_syntax():
     client = shunt(any_llm, SinkStream(buf))
 
     response = client.completion(
-        model='openai:gpt-3.5-turbo',
-        messages=[{'role': 'user', 'content': 'Reply with the single word: ping'}],
+        model=f'openai:{_MODEL}',
+        messages=[{'role': 'user', 'content': 'Reply with the single word: red'}],
     )
 
-    assert response.choices[0].message.content.lower().strip() == 'ping'
+    assert response.choices[0].message.content.lower().strip() == 'red'
 
     record = json.loads(buf.getvalue().strip())
 
     assert record['client'] == 'any_llm'
     assert record['method'] == 'completion'
-    assert record['request']['model'] == 'openai:gpt-3.5-turbo'
+    assert record['request']['model'] == f'openai:{_MODEL}'
     assert record['error'] is None
     assert record['duration_ms'] > 0
-    assert record['response']['choices'][0]['message']['content'].lower().strip() == 'ping'
+    assert (
+        record['response']['choices'][0]['message']['content'].lower().strip() == 'red'
+    )

--- a/test/adhoc/test_any_llm.py
+++ b/test/adhoc/test_any_llm.py
@@ -1,0 +1,62 @@
+import io
+import json
+import os
+
+import pytest
+
+try:
+    import any_llm
+except ImportError:
+    pytest.skip("any-llm-sdk not available", allow_module_level=True)
+
+from shuntly import SinkStream, shunt
+
+_OPENAI_API_KEY = os.environ.get('OPENAI_API_KEY')
+_MODEL = 'gpt-3.5-turbo'
+
+pytestmark = pytest.mark.skipif(not _OPENAI_API_KEY, reason='OPENAI_API_KEY not set')
+
+
+def test_wrap_captures_record():
+    buf = io.StringIO()
+    client = shunt(any_llm, SinkStream(buf))
+
+    response = client.completion(
+        model=_MODEL,
+        provider='openai',
+        messages=[{'role': 'user', 'content': 'Reply with the single word: pong'}],
+    )
+
+    assert response.choices[0].message.content.lower().strip() == 'pong'
+
+    record = json.loads(buf.getvalue().strip())
+
+    assert record['client'] == 'any_llm'
+    assert record['method'] == 'completion'
+    assert record['request']['model'] == _MODEL
+    assert record['request']['provider'] == 'openai'
+    assert record['error'] is None
+    assert record['duration_ms'] > 0
+    assert record['response']['choices'][0]['message']['content'].lower().strip() == 'pong'
+
+
+def test_wrap_captures_alternative_syntax():
+    """Test the provider:model syntax supported by any-llm."""
+    buf = io.StringIO()
+    client = shunt(any_llm, SinkStream(buf))
+
+    response = client.completion(
+        model='openai:gpt-3.5-turbo',
+        messages=[{'role': 'user', 'content': 'Reply with the single word: ping'}],
+    )
+
+    assert response.choices[0].message.content.lower().strip() == 'ping'
+
+    record = json.loads(buf.getvalue().strip())
+
+    assert record['client'] == 'any_llm'
+    assert record['method'] == 'completion'
+    assert record['request']['model'] == 'openai:gpt-3.5-turbo'
+    assert record['error'] is None
+    assert record['duration_ms'] > 0
+    assert record['response']['choices'][0]['message']['content'].lower().strip() == 'ping'


### PR DESCRIPTION
Adds support for Mozilla AI's any-llm unified LLM provider interface.

## Changes

- **Dependencies**: Add `any-llm-sdk==1.8.5` to dev dependencies
- **Core**: Register `any_llm.completion` in METHOD_REGISTRY for auto-wrapping
- **Tests**: Comprehensive test coverage for both syntax variants:
  - Standard: `completion(model="gpt-3.5-turbo", provider="openai")`
  - Combined: `completion(model="openai:gpt-3.5-turbo")`

## About any-llm

[any-llm](https://github.com/mozilla-ai/any-llm) is Mozilla AI's unified interface for LLM providers. It provides a single `completion()` function that works with OpenAI, Anthropic, Mistral, Ollama, and more without changing your code.

## Testing

Run the new test with:
```bash
OPENAI_API_KEY=your_key python -m pytest test/adhoc/test_any_llm.py -v
```

The test validates that shuntly correctly captures requests and responses from any-llm's `completion()` function using OpenAI as the backend provider.

## Implementation Notes

- Follows shuntly's existing patterns - no special handling needed
- `any_llm.completion` returns standard OpenAI-compatible response objects
- Works with both syntax variants any-llm supports
- Minimal invasive change: just one line in METHOD_REGISTRY + tests

---

**Note**: Supersedes PR #9 (which accidentally included SinkS3 changes). This PR contains only the any-llm support changes.