### PR TITLE
feat: add support for Ollama Python SDK

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,7 @@ Shuntly presently handles these clients:
 | `google.genai.Client` | [`PyPI`](https://pypi.org/project/google-genai) | `models.generate_content` |
 | `litellm` | [`PyPI`](https://pypi.org/project/litellm) | `completion` |
 | `any-llm` | [`PyPI`](https://pypi.org/project/any-llm-sdk) | `completion` |
+| `ollama`, `ollama.Client` | [`PyPI`](https://pypi.org/project/ollama) | `chat`, `generate` |
 
 For anything else, method paths can be explicitly provided:
 
@@ -177,6 +178,8 @@ client = shunt(my_client, methods=["chat.send", "embeddings.create"])
 ### dev
 
 Added support for Mozilla `any_llm.completion()`
+
+Added support for Ollama interfaces.
 
 
 ### 0.7.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,7 @@ dev = [
     "litellm==1.81.10",
     "python-dotenv==1.2.1",
     "any-llm-sdk[openai]==1.8.5; python_version>='3.11'",
+    "ollama==0.6.1",
     ]
 
 [tool.setuptools.packages.find]

--- a/shuntly/core.py
+++ b/shuntly/core.py
@@ -29,6 +29,10 @@ _METHOD_REGISTRY: dict[str, list[str]] = {
     'any_llm': [
         'completion',
     ],
+    'ollama': [
+        'chat',
+        'generate',
+    ],
 }
 
 

--- a/shuntly/core.py
+++ b/shuntly/core.py
@@ -33,6 +33,10 @@ _METHOD_REGISTRY: dict[str, list[str]] = {
         'chat',
         'generate',
     ],
+    'ollama._client.Client': [
+        'chat',
+        'generate',
+    ],
 }
 
 

--- a/test/adhoc/test_ollama.py
+++ b/test/adhoc/test_ollama.py
@@ -1,0 +1,105 @@
+import io
+import json
+
+import pytest
+
+try:
+    import ollama
+except ImportError:
+    pytest.skip("ollama not available", allow_module_level=True)
+
+from shuntly import SinkStream, shunt
+
+_MODEL = 'qwen2.5:0.5b'  # Small model for testing
+
+# Skip tests if Ollama isn't running or model isn't available
+def _check_ollama_available():
+    try:
+        available_models = ollama.list()
+        model_names = [model['name'] for model in available_models.get('models', [])]
+        return any(_MODEL in name for name in model_names)
+    except:
+        return False
+
+pytestmark = pytest.mark.skipif(
+    not _check_ollama_available(), 
+    reason=f'Ollama not running or model {_MODEL} not available'
+)
+
+
+def test_wrap_captures_chat_record():
+    buf = io.StringIO()
+    client = shunt(ollama, SinkStream(buf))
+
+    response = client.chat(
+        model=_MODEL,
+        messages=[{'role': 'user', 'content': 'Reply with just the word: pong'}],
+    )
+
+    # Verify the response has the expected structure
+    assert 'message' in response
+    assert 'content' in response['message']
+    
+    record = json.loads(buf.getvalue().strip())
+
+    assert record['client'] == 'ollama'
+    assert record['method'] == 'chat'
+    assert record['request']['model'] == _MODEL
+    assert record['request']['messages'][0]['content'] == 'Reply with just the word: pong'
+    assert record['error'] is None
+    assert record['duration_ms'] > 0
+    assert 'message' in record['response']
+
+
+def test_wrap_captures_generate_record():
+    buf = io.StringIO()
+    client = shunt(ollama, SinkStream(buf))
+
+    response = client.generate(
+        model=_MODEL,
+        prompt='Reply with just the word: ping',
+    )
+
+    # Verify the response has the expected structure
+    assert 'response' in response
+    
+    record = json.loads(buf.getvalue().strip())
+
+    assert record['client'] == 'ollama'
+    assert record['method'] == 'generate'
+    assert record['request']['model'] == _MODEL
+    assert record['request']['prompt'] == 'Reply with just the word: ping'
+    assert record['error'] is None
+    assert record['duration_ms'] > 0
+    assert 'response' in record['response']
+
+
+def test_wrap_captures_streaming_chat():
+    """Test streaming chat responses are captured correctly."""
+    buf = io.StringIO()
+    client = shunt(ollama, SinkStream(buf))
+
+    chunks = []
+    stream = client.chat(
+        model=_MODEL,
+        messages=[{'role': 'user', 'content': 'Count to 3'}],
+        stream=True,
+    )
+
+    for chunk in stream:
+        chunks.append(chunk)
+
+    # Verify we got streaming chunks
+    assert len(chunks) > 0
+    assert all('message' in chunk for chunk in chunks)
+
+    record = json.loads(buf.getvalue().strip())
+
+    assert record['client'] == 'ollama'
+    assert record['method'] == 'chat'
+    assert record['request']['model'] == _MODEL
+    assert record['request']['stream'] is True
+    assert record['error'] is None
+    assert record['duration_ms'] > 0
+    # Response should be the accumulated chunks
+    assert record['response'] == chunks

--- a/test/adhoc/test_ollama.py
+++ b/test/adhoc/test_ollama.py
@@ -1,105 +1,101 @@
 import io
 import json
+import os
 
+import ollama
 import pytest
-
-try:
-    import ollama
-except ImportError:
-    pytest.skip("ollama not available", allow_module_level=True)
 
 from shuntly import SinkStream, shunt
 
-_MODEL = 'qwen2.5:0.5b'  # Small model for testing
+_API_KEY = os.environ.get('OLLAMA_API_KEY')
+_MODEL = 'nemotron-3-nano:30b'
 
-# Skip tests if Ollama isn't running or model isn't available
-def _check_ollama_available():
-    try:
-        available_models = ollama.list()
-        model_names = [model['name'] for model in available_models.get('models', [])]
-        return any(_MODEL in name for name in model_names)
-    except:
-        return False
+pytestmark = pytest.mark.skipif(not _API_KEY, reason='OLLAMA_API_KEY not set')
 
-pytestmark = pytest.mark.skipif(
-    not _check_ollama_available(), 
-    reason=f'Ollama not running or model {_MODEL} not available'
-)
+
+def _make_client():
+    return ollama.Client(
+        host='https://ollama.com',
+        headers={'Authorization': f'Bearer {_API_KEY}'},
+    )
 
 
 def test_wrap_captures_chat_record():
     buf = io.StringIO()
-    client = shunt(ollama, SinkStream(buf))
+    client = shunt(_make_client(), SinkStream(buf))
 
     response = client.chat(
         model=_MODEL,
         messages=[{'role': 'user', 'content': 'Reply with just the word: pong'}],
     )
 
-    # Verify the response has the expected structure
     assert 'message' in response
     assert 'content' in response['message']
-    
+
     record = json.loads(buf.getvalue().strip())
 
-    assert record['client'] == 'ollama'
+    assert record['client'] == 'ollama._client.Client'
     assert record['method'] == 'chat'
     assert record['request']['model'] == _MODEL
-    assert record['request']['messages'][0]['content'] == 'Reply with just the word: pong'
     assert record['error'] is None
     assert record['duration_ms'] > 0
     assert 'message' in record['response']
+    assert record['response']['message']['content'].strip() == 'pong'
 
 
 def test_wrap_captures_generate_record():
     buf = io.StringIO()
-    client = shunt(ollama, SinkStream(buf))
+    client = shunt(_make_client(), SinkStream(buf))
 
     response = client.generate(
         model=_MODEL,
         prompt='Reply with just the word: ping',
     )
 
-    # Verify the response has the expected structure
     assert 'response' in response
-    
+
     record = json.loads(buf.getvalue().strip())
 
-    assert record['client'] == 'ollama'
+    assert record['client'] == 'ollama._client.Client'
     assert record['method'] == 'generate'
     assert record['request']['model'] == _MODEL
     assert record['request']['prompt'] == 'Reply with just the word: ping'
     assert record['error'] is None
     assert record['duration_ms'] > 0
     assert 'response' in record['response']
+    assert record['response']['response'].strip() == 'ping'
 
 
 def test_wrap_captures_streaming_chat():
-    """Test streaming chat responses are captured correctly."""
     buf = io.StringIO()
-    client = shunt(ollama, SinkStream(buf))
+    client = shunt(_make_client(), SinkStream(buf))
 
     chunks = []
     stream = client.chat(
         model=_MODEL,
-        messages=[{'role': 'user', 'content': 'Count to 3'}],
+        messages=[
+            {'role': 'user', 'content': 'Reply with just the words: ping pong ping pong'}
+        ],
         stream=True,
     )
 
     for chunk in stream:
         chunks.append(chunk)
 
-    # Verify we got streaming chunks
     assert len(chunks) > 0
     assert all('message' in chunk for chunk in chunks)
 
     record = json.loads(buf.getvalue().strip())
 
-    assert record['client'] == 'ollama'
+    assert record['client'] == 'ollama._client.Client'
     assert record['method'] == 'chat'
     assert record['request']['model'] == _MODEL
     assert record['request']['stream'] is True
     assert record['error'] is None
     assert record['duration_ms'] > 0
-    # Response should be the accumulated chunks
-    assert record['response'] == chunks
+    assert isinstance(record['response'], list)
+    assert len(record['response']) > 0
+
+    responses = record['response']
+    post = ''.join(r['message']['content'].strip() for r in responses)
+    assert post == 'pingpongpingpong'


### PR DESCRIPTION
Adds support for the Ollama Python SDK, enabling capture of local LLM requests and responses.

## Changes

- **Dependencies**: Add `ollama==0.6.1` to dev dependencies
- **Core**: Register `ollama.chat` and `ollama.generate` in METHOD_REGISTRY for auto-wrapping
- **Tests**: Comprehensive test coverage for both functions:
  - `chat()` - message-based chat interface
  - `generate()` - prompt-based text generation
  - Streaming responses with `stream=True`

## About Ollama

[Ollama](https://github.com/ollama/ollama) enables running LLMs locally. The Python SDK provides `chat()` and `generate()` functions that work with any model available in Ollama's library.

## Testing

The tests use `qwen2.5:0.5b` (a lightweight 0.5B parameter model) and automatically skip if:
- Ollama isn't installed/running
- The test model isn't available locally

To run the tests:
```bash
# Install and start Ollama
ollama pull qwen2.5:0.5b

# Run the tests
python -m pytest test/adhoc/test_ollama.py -v
```

## Implementation Notes

- Follows shuntly's established patterns - no special handling needed
- Supports both sync and streaming modes
- Works with any Ollama model (gemma, llama, qwen, etc.)
- Captures full request/response including model parameters
- Auto-detects available models for graceful test skipping

## Use Cases

- Debug local LLM applications
- Monitor performance of different models
- Log conversations for analysis
- Track resource usage patterns